### PR TITLE
Add checkpoint eraserv2

### DIFF
--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -104,6 +104,8 @@ def run(args, parser):
             args.experiment_name: {  # i.e. log to ~/ray_results/default
                 "run": args.run,
                 "checkpoint_freq": args.checkpoint_freq,
+                "keep_checkpoint": args.keep_checkpoint,
+                "keep_best_checkpoint": args.keep_best_checkpoint,
                 "local_dir": args.local_dir,
                 "resources_per_trial": (
                     args.resources_per_trial and

--- a/python/ray/rllib/train.py
+++ b/python/ray/rllib/train.py
@@ -104,8 +104,8 @@ def run(args, parser):
             args.experiment_name: {  # i.e. log to ~/ray_results/default
                 "run": args.run,
                 "checkpoint_freq": args.checkpoint_freq,
-                "keep_checkpoint": args.keep_checkpoint,
-                "keep_best_checkpoint": args.keep_best_checkpoint,
+                "keep_checkpoints_num": args.keep_checkpoints_num,
+                "keep_best_checkpoints_num": args.keep_best_checkpoints_num,
                 "local_dir": args.local_dir,
                 "resources_per_trial": (
                     args.resources_per_trial and

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -104,18 +104,18 @@ def make_parser(parser_creator=None, **kwargs):
         help="Whether to checkpoint at the end of the experiment. "
         "Default is False.")
     parser.add_argument(
-        "--keep-best-checkpoint",
-        default=0,
+        "--keep-best-checkpoints-num",
+        default=None,
         type=int,
-        help="Number of highest reward checkpoints to keep. Value of 0 (default)"
+        help="Number of highest reward checkpoints to keep. Default (None) "
              "disables best checkpointing."
     )
     parser.add_argument(
-        "--keep-checkpoint",
-        default=0,
+        "--keep-checkpoints-num",
+        default=None,
         type=int,
         help="Number of last checkpoints to keep. Others get "
-             "deleted. Value of 0 (default) keeps all checkpoints."
+             "deleted. Default (None) keeps all checkpoints."
     )
     parser.add_argument(
         "--export-formats",
@@ -157,6 +157,8 @@ def to_argv(config):
     for k, v in config.items():
         if "-" in k:
             raise ValueError("Use '_' instead of '-' in `{}`".format(k))
+        if v is None:
+            continue
         if not isinstance(v, bool) or v:  # for argparse flags
             argv.append("--{}".format(k.replace("_", "-")))
         if isinstance(v, string_types):
@@ -202,8 +204,8 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
         stopping_criterion=spec.get("stop", {}),
         checkpoint_freq=args.checkpoint_freq,
         checkpoint_at_end=args.checkpoint_at_end,
-        keep_best_checkpoint=args.keep_best_checkpoint,
-        keep_checkpoint=args.keep_checkpoint,
+        keep_best_checkpoints_num=args.keep_best_checkpoints_num,
+        keep_checkpoints_num=args.keep_checkpoints_num,
         export_formats=spec.get("export_formats", []),
         # str(None) doesn't create None
         restore_path=spec.get("restore"),

--- a/python/ray/tune/config_parser.py
+++ b/python/ray/tune/config_parser.py
@@ -104,6 +104,20 @@ def make_parser(parser_creator=None, **kwargs):
         help="Whether to checkpoint at the end of the experiment. "
         "Default is False.")
     parser.add_argument(
+        "--keep-best-checkpoint",
+        default=0,
+        type=int,
+        help="Number of highest reward checkpoints to keep. Value of 0 (default)"
+             "disables best checkpointing."
+    )
+    parser.add_argument(
+        "--keep-checkpoint",
+        default=0,
+        type=int,
+        help="Number of last checkpoints to keep. Others get "
+             "deleted. Value of 0 (default) keeps all checkpoints."
+    )
+    parser.add_argument(
         "--export-formats",
         default=None,
         help="List of formats that exported at the end of the experiment. "
@@ -188,6 +202,8 @@ def create_trial_from_spec(spec, output_path, parser, **trial_kwargs):
         stopping_criterion=spec.get("stop", {}),
         checkpoint_freq=args.checkpoint_freq,
         checkpoint_at_end=args.checkpoint_at_end,
+        keep_best_checkpoint=args.keep_best_checkpoint,
+        keep_checkpoint=args.keep_checkpoint,
         export_formats=spec.get("export_formats", []),
         # str(None) doesn't create None
         restore_path=spec.get("restore"),

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -73,10 +73,10 @@ class Experiment(object):
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
-        keep_checkpoint (int) : Number of last checkpoints to keep. Others get
-             deleted. Value of 0 (default) keeps all checkpoints.
-        keep_best_checkpoint (int): Number of highest reward checkpoints to keep.
-            Value of 0 (default) disables best checkpointing.
+        keep_checkpoints_num (int) : Number of last checkpoints to keep. Others get
+             deleted. Default is None - keeps all checkpoints.
+        keep_best_checkpoints_num (int): Number of highest reward checkpoints to keep.
+            Default value of None disables it.
         export_formats (list): List of formats that exported at the end of
             the experiment. Default is None.
         max_failures (int): Try to recover a trial from its last
@@ -129,8 +129,8 @@ class Experiment(object):
                  sync_function=None,
                  checkpoint_freq=0,
                  checkpoint_at_end=False,
-                 keep_best_checkpoint=None,
-                 keep_checkpoint=None,
+                 keep_best_checkpoints_num=None,
+                 keep_checkpoints_num=None,
                  export_formats=None,
                  max_failures=3,
                  restore=None,
@@ -161,8 +161,8 @@ class Experiment(object):
             "sync_function": sync_function,
             "checkpoint_freq": checkpoint_freq,
             "checkpoint_at_end": checkpoint_at_end,
-            "keep_best_checkpoint": keep_best_checkpoint,
-            "keep_checkpoint": keep_checkpoint,
+            "keep_best_checkpoints_num": keep_best_checkpoints_num,
+            "keep_checkpoints_num": keep_checkpoints_num,
             "export_formats": export_formats or [],
             "max_failures": max_failures,
             "restore": restore

--- a/python/ray/tune/experiment.py
+++ b/python/ray/tune/experiment.py
@@ -73,6 +73,10 @@ class Experiment(object):
             checkpoints. A value of 0 (default) disables checkpointing.
         checkpoint_at_end (bool): Whether to checkpoint at the end of the
             experiment regardless of the checkpoint_freq. Default is False.
+        keep_checkpoint (int) : Number of last checkpoints to keep. Others get
+             deleted. Value of 0 (default) keeps all checkpoints.
+        keep_best_checkpoint (int): Number of highest reward checkpoints to keep.
+            Value of 0 (default) disables best checkpointing.
         export_formats (list): List of formats that exported at the end of
             the experiment. Default is None.
         max_failures (int): Try to recover a trial from its last
@@ -125,6 +129,8 @@ class Experiment(object):
                  sync_function=None,
                  checkpoint_freq=0,
                  checkpoint_at_end=False,
+                 keep_best_checkpoint=None,
+                 keep_checkpoint=None,
                  export_formats=None,
                  max_failures=3,
                  restore=None,
@@ -155,6 +161,8 @@ class Experiment(object):
             "sync_function": sync_function,
             "checkpoint_freq": checkpoint_freq,
             "checkpoint_at_end": checkpoint_at_end,
+            "keep_best_checkpoint": keep_best_checkpoint,
+            "keep_checkpoint": keep_checkpoint,
             "export_formats": export_formats or [],
             "max_failures": max_failures,
             "restore": restore

--- a/python/ray/tune/ray_trial_executor.py
+++ b/python/ray/tune/ray_trial_executor.py
@@ -440,6 +440,7 @@ class RayTrialExecutor(TrialExecutor):
         if storage == Checkpoint.MEMORY:
             trial._checkpoint.value = trial.runner.save_to_object.remote()
         else:
+            # If enabled, saves best checkpoints into a best folder
             if trial.keep_best_checkpoints_num and trial.results_since_checkpoint_cnt > 0:
                 mean_rew_since_checkpoint = trial.results_since_checkpoint_sum / trial.results_since_checkpoint_cnt
                 if mean_rew_since_checkpoint > trial.best_checkpoint_reward:

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -220,7 +220,7 @@ class Trainable(object):
         folder_path = os.path.join(self.logdir, relative_dir)
         return self.save(folder_path), os.path.join(folder_path, "checkpoint_{}".format(self._iteration))
 
-    def delete_checkpoint_relative(self, path):
+    def delete_checkpoint(self, path):
         """Removes subdirectory within checkpoint_folder
 
         Parameters

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -220,15 +220,15 @@ class Trainable(object):
         folder_path = os.path.join(self.logdir, relative_dir)
         return self.save(folder_path), os.path.join(folder_path, "checkpoint_{}".format(self._iteration))
 
-    def delete_checkpoint(self, path):
+    def delete_checkpoint(self, checkpoint_dir):
         """Removes subdirectory within checkpoint_folder
 
         Parameters
         ----------
-            path : path to checkpoint
+            checkpoint_dir : path to checkpoint
 
         """
-        shutil.rmtree(path)
+        shutil.rmtree(checkpoint_dir)
 
     def save(self, checkpoint_dir=None):
         """Saves the current model state to a checkpoint.

--- a/python/ray/tune/trainable.py
+++ b/python/ray/tune/trainable.py
@@ -205,6 +205,31 @@ class Trainable(object):
 
         return result
 
+    def save_checkpoint_relative(self, relative_dir):
+        """Saves checkpoints relative to logdir folder.
+
+        Parameters
+        ----------
+            relative_dir : path of subdirectory to save to
+
+        Returns
+        -------
+            checkpoint_path, checkpoint_folder_path
+
+        """
+        folder_path = os.path.join(self.logdir, relative_dir)
+        return self.save(folder_path), os.path.join(folder_path, "checkpoint_{}".format(self._iteration))
+
+    def delete_checkpoint_relative(self, path):
+        """Removes subdirectory within checkpoint_folder
+
+        Parameters
+        ----------
+            path : path to checkpoint
+
+        """
+        shutil.rmtree(path)
+
     def save(self, checkpoint_dir=None):
         """Saves the current model state to a checkpoint.
 

--- a/python/ray/tune/trial.py
+++ b/python/ray/tune/trial.py
@@ -516,9 +516,12 @@ class Trial(object):
         self.last_update_time = time.time()
         self.result_logger.on_result(self.last_result)
 
-        if not math.isnan(result["episode_reward_mean"]):
-            self.results_since_checkpoint_sum += result["episode_reward_mean"]
-            self.results_since_checkpoint_cnt += 1
+        try:
+            if not math.isnan(result["episode_reward_mean"]):
+                self.results_since_checkpoint_sum += result["episode_reward_mean"]
+                self.results_since_checkpoint_cnt += 1
+        except KeyError as e:
+            raise KeyError("Warning: result has no key episde_reward_mean. Keep_best_checkpoint flag will not work.")
 
 
     def _get_trainable_cls(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add checkpoint eraser.
--keep_checkpoint specifies how many last checkpoints to keep on disk, default is 0 which means keep all checkpoints
--keep_best_checkpoint specifies how many highest reward checkpoints to keep, default is 0 which means dont keep score of highest reward checkpoints

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
