### PR TITLE
[ray]Add support for separate docker containers on head and worker nodes in ray auto-scaler

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -38,6 +38,8 @@ REQUIRED, OPTIONAL = True, False
 
 # For (a, b), if a is a dictionary object, then
 # no extra fields can be introduced.
+
+
 CLUSTER_CONFIG_SCHEMA = {
     # An unique identifier for the head node and workers of this cluster.
     "cluster_name": (str, REQUIRED),
@@ -89,9 +91,12 @@ CLUSTER_CONFIG_SCHEMA = {
     # will be executed in the container.
     "docker": (
         {
-            "image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
-            "container_name": (str, OPTIONAL),  # e.g., ray_docker
-            "run_options": (list, OPTIONAL),
+            "head_image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
+            "head_container_name": (str, OPTIONAL),  # e.g., ray_docker
+            "head_run_options": (list, OPTIONAL),
+            "worker_image": (str, OPTIONAL),
+            "worker_container_name": (str, OPTIONAL),
+            "worker_run_options": (list, OPTIONAL),
         },
         OPTIONAL),
 
@@ -128,8 +133,6 @@ CLUSTER_CONFIG_SCHEMA = {
     # controlled by the ray --no-restart flag and cannot be set by the user.
     "no_restart": (None, OPTIONAL),
 }
-
-
 class LoadMetrics(object):
     """Container for cluster load metrics.
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -92,11 +92,11 @@ CLUSTER_CONFIG_SCHEMA = {
     "docker": (
         {
             "head_image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
-            "head_container_name": (str, OPTIONAL),  # e.g., ray_docker
             "head_run_options": (list, OPTIONAL),
             "worker_image": (str, OPTIONAL),
-            "worker_container_name": (str, OPTIONAL),
             "worker_run_options": (list, OPTIONAL),
+            "container_name": (str, OPTIONAL),  # e.g., ray_docker
+
         },
         OPTIONAL),
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -36,7 +36,6 @@ REQUIRED, OPTIONAL = True, False
 # For (a, b), if a is a dictionary object, then
 # no extra fields can be introduced.
 
-
 CLUSTER_CONFIG_SCHEMA = {
     # An unique identifier for the head node and workers of this cluster.
     "cluster_name": (str, REQUIRED),
@@ -101,7 +100,6 @@ CLUSTER_CONFIG_SCHEMA = {
             "worker_image": (str, OPTIONAL),
             # analogous to head_run_options
             "worker_run_options": (list, OPTIONAL),
-
         },
         OPTIONAL),
 
@@ -628,8 +626,9 @@ class StandardAutoscaler(object):
         self.launch_queue.put((config, count))
 
     def workers(self):
-        return self.provider.non_terminated_nodes(
-            tag_filters={TAG_RAY_NODE_TYPE: "worker"})
+        return self.provider.non_terminated_nodes(tag_filters={
+            TAG_RAY_NODE_TYPE: "worker"
+        })
 
     def log_info_string(self, nodes):
         logger.info("StandardAutoscaler: {}".format(self.info_string(nodes)))
@@ -742,7 +741,7 @@ def hash_runtime_conf(file_mounts, extra_objs):
     def add_content_hashes(path):
         def add_hash_of_file(fpath):
             with open(fpath, "rb") as f:
-                for chunk in iter(lambda: f.read(2 ** 20), b''):
+                for chunk in iter(lambda: f.read(2**20), b''):
                     hasher.update(chunk)
 
         path = os.path.expanduser(path)

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -88,11 +88,17 @@ CLUSTER_CONFIG_SCHEMA = {
     # will be executed in the container.
     "docker": (
         {
-            "head_image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
-            "head_run_options": (list, OPTIONAL),
-            "worker_image": (str, OPTIONAL),
-            "worker_run_options": (list, OPTIONAL),
+            "image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
             "container_name": (str, OPTIONAL),  # e.g., ray_docker
+            "run_options": (list, OPTIONAL),  # options for head/worker docker
+
+            # image for head node, takes precedence over "image" if specified
+            "head_image": (str, OPTIONAL),
+            # head specific run options, appended to run_options
+            "head_run_options": (list, OPTIONAL),
+            "worker_image": (str, OPTIONAL),  # analogous to head_image
+            # analogous to head_run_options
+            "worker_run_options": (list, OPTIONAL),
 
         },
         OPTIONAL),

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -136,6 +136,8 @@ CLUSTER_CONFIG_SCHEMA = {
     # controlled by the ray --no-restart flag and cannot be set by the user.
     "no_restart": (None, OPTIONAL),
 }
+
+
 class LoadMetrics(object):
     """Container for cluster load metrics.
 
@@ -656,7 +658,7 @@ def typename(v):
 
 def check_required(config, schema):
     # Check required schema entries
-    if type(config) is not dict:
+    if not isinstance(config, dict):
         raise ValueError("Config is not a dictionary")
 
     for k, (v, kreq) in schema.items():
@@ -674,7 +676,7 @@ def check_required(config, schema):
 
 def check_extraneous(config, schema):
     """Make sure all items of config are in schema"""
-    if type(config) is not dict:
+    if not isinstance(config, dict):
         raise ValueError("Config {} is not a dictionary".format(config))
     for k in config:
         if k not in schema:
@@ -697,7 +699,7 @@ def check_extraneous(config, schema):
 
 def validate_config(config, schema=CLUSTER_CONFIG_SCHEMA):
     """Required Dicts indicate that no extra fields can be introduced."""
-    if type(config) is not dict:
+    if not isinstance(config, dict):
         raise ValueError("Config {} is not a dictionary".format(config))
 
     check_required(config, schema)
@@ -738,7 +740,7 @@ def hash_runtime_conf(file_mounts, extra_objs):
     def add_content_hashes(path):
         def add_hash_of_file(fpath):
             with open(fpath, "rb") as f:
-                for chunk in iter(lambda: f.read(2**20), b''):
+                for chunk in iter(lambda: f.read(2 ** 20), b''):
                     hasher.update(chunk)
 
         path = os.path.expanduser(path)

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -3,34 +3,31 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import json
 import hashlib
+import json
+import logging
 import math
 import os
-from six import string_types
-from six.moves import queue
 import subprocess
 import threading
-import logging
 import time
-
 from collections import defaultdict
 
 import numpy as np
+import ray.services as services
 import yaml
-
-from ray.ray_constants import AUTOSCALER_MAX_NUM_FAILURES, \
-    AUTOSCALER_MAX_LAUNCH_BATCH, AUTOSCALER_MAX_CONCURRENT_LAUNCHES,\
-    AUTOSCALER_UPDATE_INTERVAL_S, AUTOSCALER_HEARTBEAT_TIMEOUT_S
+from ray.autoscaler.docker import dockerize_if_needed
 from ray.autoscaler.node_provider import get_node_provider, \
     get_default_config
-from ray.autoscaler.updater import NodeUpdaterThread
-from ray.autoscaler.docker import dockerize_if_needed
 from ray.autoscaler.tags import (TAG_RAY_LAUNCH_CONFIG, TAG_RAY_RUNTIME_CONFIG,
                                  TAG_RAY_NODE_STATUS, TAG_RAY_NODE_TYPE,
                                  TAG_RAY_NODE_NAME)
-
-import ray.services as services
+from ray.autoscaler.updater import NodeUpdaterThread
+from ray.ray_constants import AUTOSCALER_MAX_NUM_FAILURES, \
+    AUTOSCALER_MAX_LAUNCH_BATCH, AUTOSCALER_MAX_CONCURRENT_LAUNCHES, \
+    AUTOSCALER_UPDATE_INTERVAL_S, AUTOSCALER_HEARTBEAT_TIMEOUT_S
+from six import string_types
+from six.moves import queue
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -90,13 +90,15 @@ CLUSTER_CONFIG_SCHEMA = {
         {
             "image": (str, OPTIONAL),  # e.g. tensorflow/tensorflow:1.5.0-py3
             "container_name": (str, OPTIONAL),  # e.g., ray_docker
-            "run_options": (list, OPTIONAL),  # options for head/worker docker
+            # shared options for starting head/worker docker
+            "run_options": (list, OPTIONAL),
 
             # image for head node, takes precedence over "image" if specified
             "head_image": (str, OPTIONAL),
             # head specific run options, appended to run_options
             "head_run_options": (list, OPTIONAL),
-            "worker_image": (str, OPTIONAL),  # analogous to head_image
+            # analogous to head_image
+            "worker_image": (str, OPTIONAL),
             # analogous to head_run_options
             "worker_run_options": (list, OPTIONAL),
 

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -22,6 +22,16 @@ docker:
     container_name: "" # e.g. ray_docker
     run_options: []  # Extra options to pass into "docker run"
 
+    # Example of running a GPU head with CPU workers
+    # container_name: "ray-docker"
+
+    # head_image: "tensorflow/tensorflow:1.5.0-py3"
+    # head_run_options:
+    #     - --runtime=nvidia
+
+    # worker_image: "ubuntu:18.04"
+    # worker_run_options: []
+
 # The autoscaler will scale up the cluster to this target fraction of resource
 # usage. For example, if a cluster of 10 nodes is 100% busy and
 # target_utilization is 0.8, it would resize the cluster to 13. This fraction

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -27,7 +27,7 @@ def dockerize_if_needed(config):
     worker_run_options = config["docker"].get("worker_run_options", [])
 
     ssh_user = config["auth"]["ssh_user"]
-    if not docker_image:
+    if not any([docker_image, head_docker_image, worker_docker_image]):
         if cname:
             logger.warning(
                 "dockerize_if_needed: "

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -16,55 +16,55 @@ def dockerize_if_needed(config):
     if "docker" not in config:
         return config
 
+    cname = config["docker"].get("container_name")
+
     head_docker_image = config["docker"].get("head_image")
-    head_cname = config["docker"].get("head_container_name")
     head_run_options = config["docker"].get("head_run_options", [])
 
     worker_docker_image = config["docker"].get(
         "worker_image", head_docker_image)
-    worker_cname = config["docker"].get("worker_container_name", head_cname)
     worker_run_options = config["docker"].get(
         "worker_run_options", head_run_options)
 
     ssh_user = config["auth"]["ssh_user"]
     if not head_docker_image or not worker_docker_image:
-        if head_cname:
+        if cname:
             logger.warning(
                 "dockerize_if_needed: "
                 "Container name given but no Docker image - continuing...")
         return config
     else:
-        assert head_cname, "Must provide head container name!"
+        assert cname, "Must provide head container name!"
     docker_mounts = {dst: dst for dst in config["file_mounts"]}
 
     head_setup_commands = with_docker_exec(
-        config["setup_commands"], container_name=head_cname)
+        config["setup_commands"], container_name=cname)
     head_docker_start = docker_start_cmds(
         ssh_user,
         head_docker_image,
         docker_mounts,
-        head_cname,
+        cname,
         head_run_options)
 
     worker_setup_commands = with_docker_exec(
-        config["setup_commands"], container_name=worker_cname)
+        config["setup_commands"], container_name=cname)
     worker_docker_start = docker_start_cmds(
         ssh_user,
         worker_docker_image,
         docker_mounts,
-        worker_cname,
+        cname,
         worker_run_options)
 
     config["head_setup_commands"] = head_docker_start + head_setup_commands \
         + with_docker_exec(config["head_setup_commands"],
-                           container_name=head_cname)
+                           container_name=cname)
     config["head_start_ray_commands"] = (
-        docker_autoscaler_setup(head_cname) + with_docker_exec(
-            config["head_start_ray_commands"], container_name=head_cname))
+        docker_autoscaler_setup(cname) + with_docker_exec(
+            config["head_start_ray_commands"], container_name=cname))
 
     config["worker_setup_commands"] = worker_docker_start + \
         worker_setup_commands + with_docker_exec(
-        config["worker_setup_commands"], container_name=worker_cname)
+        config["worker_setup_commands"], container_name=cname)
     config["worker_start_ray_commands"] = with_docker_exec(
         config["worker_start_ray_commands"],
         container_name=worker_setup_commands,

--- a/python/ray/autoscaler/docker.py
+++ b/python/ray/autoscaler/docker.py
@@ -40,19 +40,13 @@ def dockerize_if_needed(config):
     setup_commands = with_docker_exec(
         config["setup_commands"], container_name=cname)
 
-    head_docker_start = docker_start_cmds(
-        ssh_user,
-        head_docker_image,
-        docker_mounts,
-        cname,
-        run_options + head_run_options)
+    head_docker_start = docker_start_cmds(ssh_user, head_docker_image,
+                                          docker_mounts, cname,
+                                          run_options + head_run_options)
 
-    worker_docker_start = docker_start_cmds(
-        ssh_user,
-        worker_docker_image,
-        docker_mounts,
-        cname,
-        run_options + worker_run_options)
+    worker_docker_start = docker_start_cmds(ssh_user, worker_docker_image,
+                                            docker_mounts, cname,
+                                            run_options + worker_run_options)
 
     config["head_setup_commands"] = head_docker_start + setup_commands \
         + with_docker_exec(config["head_setup_commands"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## What do these changes do?
* Node specific docker parameters can now be specified when running a cluster with docker containers.
* Added fields are:   
     * ```head_image``` - image for head node, defaults to ```image``` if not specified
     * ```worker_image``` - same as ```head_image```
     * ```head_run_options``` - appended to ```run_options``` on head node
     * ```worker_run_options``` - same as ```head_run_options```

## Related issue number

<!-- For example: "Closes #1234" -->

## Linter

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
